### PR TITLE
#19 トリガでエラーが起きていないか確認するためのメソッドを追加

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -2,6 +2,7 @@
 
 var CHANNEL_ACCESS_TOKEN = PropertiesService.getScriptProperties().getProperty("CHANNEL_ACCESS_TOKEN");
 var GOOGLE_API_KEY = PropertiesService.getScriptProperties().getProperty("GOOGLE_API_KEY");
+var HEALTH_CHECK_URL = PropertiesService.getScriptProperties().getProperty("HEALTH_CHECK_URL");
 
 function getUsername(userId) {
   var url = 'https://api.line.me/v2/bot/profile/' + userId;
@@ -191,4 +192,33 @@ function doPost(e) {
 
   return JSON.stringify({});
 
+}
+
+// HealthCheck用ダミーGETメソッド
+function doGet() {
+  return ContentService.createTextOutput(JSON.stringify('{"success":true}')).setMimeType(ContentService.MimeType.JSON);
+}
+
+// HealthCheck invoke by scheduled trigger
+function checkSelf() {
+  var url = HEALTH_CHECK_URL;
+  var response;
+  try {
+    response = UrlFetchApp.fetch(url, {
+      "muteHttpExceptions" : true,
+      "validateHttpsCertificates" : false,
+      "followRedirects" : true
+    });
+    Logger.log('checkSelf() : ' + response.getResponseCode());
+    if (response.getResponseCode() != 200) {
+      // お知らせ
+      // sendLine(ADMIN_LINE_ID, '寝たかも。 status:' + response.getResponseCode());
+    }
+    return 'OK';
+  } catch(e) {
+    // 例外エラー処理
+    Logger.log('Error:')
+    Logger.log(e)
+    return null;
+  }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16116126/201510883-6e73722a-4a10-48c8-8c36-2d42ee23a33a.png)

checkSelf()の中で自Webアプリを呼び出し、トリガから定期的に実行する。

LINEの指定する管理者アカウントに通知するようにしてみたが、再度権限の承認が必要になると、トリガの実行も失敗する状況だった。

手がかりとして、エラーの時にメール通知されるのが機能するので、これで認知できるようにはなった。

![image](https://user-images.githubusercontent.com/16116126/201511099-01c54704-8604-41c0-9da4-8f40f7f1c6bd.png)
