### PR TITLE
平均速度が誤って走行距離になってしまうケースに対処

### DIFF
--- a/tests.gs
+++ b/tests.gs
@@ -804,9 +804,50 @@ var sample29 = `2:11'25
 SUUNTO
 LIGHT LOCK`;
 
+var sample30 = `22:34
+← 現在
+さいたま
+music
+さいたま市役所 【
+サ
+別所沼公園
+裏門通り
+1
+志木街道
+Google
+ランニング
+LINE
+マンガ
+5.04
+距離 (km)
+40
+中山道
+平均ペース
+平均速度
+※
+17
+埼玉県庁
+00:24:39
+時間
+うらわ美術館
+20
+ランキングで自分の順位を確認
+191
+坂下通り
+16
+311
+カロリー
+89%
+埼玉会館
+463
+さいたま地方裁判所
+旧中山道
+04:53 min/km
+12.3km毎時`;
+
 function newTest() {
   var result = '';
-  result += detectTest('sample29', sample29, '2:11:25', '19.7'); // 秒の後ろに記号なし
+  result += detectTest('sample30', sample30, '00:24:39', '5.04'); // km毎時ってのが認識された
 
   console.log(`results: ${result}`);
 }
@@ -842,6 +883,7 @@ function myTest() {
   result += detectTest('sample27', sample27, '01:08:11', '13.009'); // EPSON タイムが180°回転して検出
   result += detectTest('sample28', sample28, '1:10:32', '5.48'); // シンプルなGARMIN
   result += detectTest('sample29', sample29, '2:11:25', '19.7'); // 秒の後ろに記号なし
+  result += detectTest('sample30', sample30, '00:24:39', '5.04'); // km毎時ってのが認識された
 
   console.log(`results: ${result}`);
 }

--- a/util.gs
+++ b/util.gs
@@ -95,24 +95,6 @@ function rotateTimeStr(src) {
 } 
 
 function detectDistance(result) {
-  // 3.70km
-  a = [...result.matchAll(/([0-9]+)\.([0-9]+)[kK][mM]/g)];
-  if ( a.length > 0) {
-    for(i=0; i<a.length;i++) {
-      distance = a[i][1] + '.' + a[i][2];
-      if(distance != '0.000') {
-        console.log(`match dd0 with ${a[i][0]} of ${a.length} patterns.`);
-        // TODO: 複数あったら返して選択してもらう。
-        return distance;
-      }
-    }
-  }
-  // 8.260 km
-  a = result.match(/([0-9]+)\.([0-9]+)[ ]*km/);
-  if ( a != null) {
-    console.log(`match dd1 with ${a[0]}`);
-    return a[1] + '.' + a[2];
-  }
   // 7.67
   // 距離(km)
   a = result.match(/([0-9]+)\.([0-9]+)\n(距離|キロメートル)/);
@@ -132,6 +114,18 @@ function detectDistance(result) {
   if ( a != null) {
     console.log(`match dd4 with ${a[0]}`);
     return a[1] + '.' + a[2];
+  }
+  // 3.70km
+  a = [...result.matchAll(/([0-9]+)\.([0-9]+)[ ]*[kK][mM]/g)];
+  if ( a.length > 0) {
+    for(i=0; i<a.length;i++) {
+      distance = a[i][1] + '.' + a[i][2];
+      if(distance != '0.000') {
+        console.log(`match dd0 with ${a[i][0]} of ${a.length} patterns.`);
+        // TODO: 複数あったら返して選択してもらう。
+        return distance;
+      }
+    }
   }
   // 8.0 14km EPSON Watchで01が 0 1になる問題
   a = result.match(/([0-9]+)\.([0-9]+) ([0-9]+)km\n/);


### PR DESCRIPTION
close #20 

dd2の優先順位を上げ、dd1はdd0にマージした。

- [x] myTestで既存のパターンを含め検出できていること。
- [x] 今回のラン画像が距離とタイムとも読み取られること。

<img width="375" alt="image" src="https://user-images.githubusercontent.com/16116126/201511985-8c0416ff-230b-4edd-b544-9052cd4308c0.png">
