### PR TITLE
#26 複数回のランを1行に集計する

### DIFF
--- a/timeMath.gs
+++ b/timeMath.gs
@@ -1,0 +1,152 @@
+// https://shanabrian.com/web/javascript/time-math.php
+var timeMath = {
+	/**
+	 * 加算
+	 */
+	sum : function() {
+		var result, times, second,
+			len = arguments.length;
+
+		if (len === 0) return;
+
+		for (var i = 0; i < len; i++) {
+			if (!arguments[i] || !arguments[i].match(/^[0-9]+:[0-9]{2}:[0-9]{2}$/)) continue;
+
+			times = arguments[i].split(':');
+
+			second = this.toSecond(times[0], times[1], times[2]);
+
+			if ((!second && second !== 0)) continue;
+
+			if (i === 0) {
+				result = second;
+			} else {
+				result += second;
+			}
+		}
+
+		return this.toTimeFormat(result);
+	},
+
+	/**
+	 * 減算
+	 */
+	sub : function() {
+		var result, times, second,
+			len = arguments.length;
+
+		if (len === 0) return;
+
+		for (var i = 0; i < len; i++) {
+			if (!arguments[i] || !arguments[i].match(/^[0-9]+:[0-9]{2}:[0-9]{2}$/)) continue;
+
+			times = arguments[i].split(':');
+
+			second = this.toSecond(times[0], times[1], times[2]);
+
+			if (!second) continue;
+
+			if (i === 0) {
+				result = second;
+			} else {
+				result -= second;
+			}
+		}
+
+		return this.toTimeFormat(result);
+	},
+
+	/**
+	 * 乗算
+	 */
+	multiply : function() {
+		var result, times, second,
+			len = arguments.length;
+
+		if (len === 0) return;
+
+		for (var i = 0; i < len; i++) {
+			if (!arguments[i] || !arguments[i].match(/^[0-9]+:[0-9]{2}:[0-9]{2}$/)) continue;
+
+			times = arguments[i].split(':');
+
+			second = this.toSecond(times[0], times[1], times[2]);
+
+			if (!second) continue;
+
+			if (i === 0) {
+				result = second;
+			} else {
+				result *= second;
+			}
+		}
+
+		return this.toTimeFormat(result);
+	},
+
+	/**
+	 * 除算
+	 */
+	division : function() {
+		var result, times, second,
+			len = arguments.length;
+
+		if (len === 0) return;
+
+		for (var i = 0; i < len; i++) {
+			if (!arguments[i] || !arguments[i].match(/^[0-9]+:[0-9]{2}:[0-9]{2}$/)) continue;
+
+			times = arguments[i].split(':');
+
+			second = this.toSecond(times[0], times[1], times[2]);
+
+			if (!second) continue;
+
+			if (i === 0) {
+				result = second;
+			} else {
+				result /= second;
+			}
+		}
+
+		return this.toTimeFormat(result);
+	},
+
+	/**
+	 * 時間を秒に変換
+	 */
+	toSecond : function(hour, minute, second) {
+		if ((!hour && hour !== 0) || (!minute && minute !== 0) || (!second && second !== 0) ||
+			hour === null || minute === null || second === null ||
+			typeof hour === 'boolean' ||
+			typeof minute === 'boolean' ||
+			typeof second === 'boolean' ||
+			typeof Number(hour) === 'NaN' ||
+			typeof Number(minute) === 'NaN' ||
+			typeof Number(second) === 'NaN') return;
+
+		return (Number(hour) * 60 * 60) + (Number(minute) * 60) + Number(second);
+	},
+
+	/**
+	 * 秒を時間（hh:mm:ss）のフォーマットに変換
+	 */
+	toTimeFormat : function(fullSecond) {
+		var hour, minute, second;
+
+		if ((!fullSecond && fullSecond !== 0) || !String(fullSecond).match(/^[\-0-9][0-9]*?$/)) return;
+
+		var paddingZero = function(n) {
+			return (n < 10)  ? '0' + n : n;
+		};
+
+		hour   = Math.floor(Math.abs(fullSecond) / 3600);
+		minute = Math.floor(Math.abs(fullSecond) % 3600 / 60);
+		second = Math.floor(Math.abs(fullSecond) % 60);
+
+		minute = paddingZero(minute);
+		second = paddingZero(second);
+
+		return ((fullSecond < 0) ? '-' : '') + hour + ':' + minute + ':' + second;
+	}
+};

--- a/util.gs
+++ b/util.gs
@@ -674,8 +674,30 @@ function getSummary(groupId) {
 
   // queryで転写された24時間以内のラン記録を取得
   var records = sheet.getRange(1,1,sheet.getLastRow(),3).getDisplayValues();
+  var runners = new Map();
   for(i = 1; i < sheet.getLastRow(); i++) {
-    result += records[i][0] + '\t' + records[i][1] + '\t' + records[i][2] + '\n';
+    if(runners.has(records[i][0])) {
+      // 回数をカウントアップし記録を加算
+      values = runners.get(records[i][0]);
+      values.count++;
+      var distance = Number(values.distance);
+      values.distance = distance + Number(records[i][1]);
+      values.duration = timeMath.sum(values.duration, records[i][2]);
+      runners.set(records[i][0], values);
+    }
+    else {
+      // 初出はセットのみ
+      runners.set(records[i][0], { name: records[i][0], count: 1, distance: records[i][1], duration: records[i][2]});
+    }
+  }
+  // 一旦マップに集計した参加者毎の記録を結果として出力
+  for (let [key, value] of runners) {
+    if(value.count == 1) {
+      result += `${key}\t${value.distance}\t${value.duration}\n`;
+    }
+    else {
+      result += `${key}(${value.count})\t${value.distance}\t${value.duration}\n`;
+    }
   }
   // 計算式で集計された合計距離・走行時間と残り距離
   var summary = sheet.getRange(1,5,3,3).getDisplayValues();


### PR DESCRIPTION
close #26 

「集計」実行時に、同じランナーの記録が複数ある場合1行にまとめるようにした。
複数回記録のあったランナーは、名前の後ろに記録数を表示するようにした。

<img width="375" alt="image" src="https://user-images.githubusercontent.com/16116126/210131579-eb2f815d-7d62-4275-a80d-2d9e9adb94ab.png">

- [x] 「集計」の結果が表示されること。
- [x] 複数ランは距離とタイムが合算され、回数が表示されること。