### PR TITLE
複数ランを合算する時、距離は小数点以下第２位までに。

### DIFF
--- a/util.gs
+++ b/util.gs
@@ -722,7 +722,8 @@ function makeResultList(records) {
       values = runners.get(records[i][0]);
       values.count++;
       var distance = Number(values.distance);
-      values.distance = distance + Number(records[i][1]);
+      // なぜか小数点以下がバグることがあるので合算する場合は小数点第二位にて切り詰め
+      values.distance = Number(distance + Number(records[i][1])).toFixed(2);
       values.duration = timeMath.sum(values.duration, records[i][2]);
       runners.set(records[i][0], values);
     }


### PR DESCRIPTION
close #38  

複数ランを合算する時、距離は小数点以下第２位までにした。

<img width="375" alt="image" src="https://user-images.githubusercontent.com/16116126/216752646-d31f8e69-7d1d-4634-ae72-837ce3c196eb.png">

- [x] 「集計」の結果が表示されること。
- [x] 「昨日の集計」の結果が表示されること。
- [x] 複数ランの距離が、小数点第２位までで表示されること。