### PR TITLE
個人の集計対応

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -126,7 +126,14 @@ function doPost(e) {
             messageText = event.message.text;
             replyToken = event.replyToken;
             if(messageText.trim().match(/^集計[\!]*/)) {
-              replyLine(sourcename, replyToken, getSummary(replyTo));
+              if(type == 'group') {
+                // グループチャット
+                replyLine(sourcename, replyToken, getSummary(replyTo));
+              }
+              else {
+                // 個人チャット
+                replyLine(sourcename, replyToken, getPersonalSummary(replyTo));
+              }
               break;
             }
             if(messageText.trim().match(/^ヘルプ/)) {

--- a/tests.gs
+++ b/tests.gs
@@ -1228,3 +1228,14 @@ function detectTest(name, result, duration, distance) {
 
   return (dd == distance && dt == duration ? 'o' : 'x');
 }
+
+// getLastMonthPeriod() のテスト
+function testLastMonthPeriod() {
+  console.log(getLastMonthPeriod(null));
+  var dt = new Date();
+  dt.setHours(6);
+  console.log(getLastMonthPeriod(dt));
+  dt.setDate(1);
+  dt.setHours(6);
+  console.log(getLastMonthPeriod(dt));
+}


### PR DESCRIPTION
close #61 

個人チャットで「集計」をした時に、当月の個人ランを集計するようにした。

- [ ] 個人チャットで「集計」を行うと、当月の集計が表示されること。
- [ ] 当月のランがない個人が「集計」を行うと、「記録はありません」と表示される。
- [ ] グループチャットで「集計」を行うと、そのグループの集計が従前通り表示される。
- [ ] 別のグループチャットで「集計」を行うと、そのグループの集計が従前通り表示される。
