### PR TITLE
取り消し以外も先頭から始まる条件に修正

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -183,7 +183,8 @@ function doPost(e) {
               replyLine(sourcename, replyToken, addResult(a[1], a[2], groupId, a[3], a[4].replaceAll('：',':')),　"", "", userId);
               break;
             }
-            if(messageText.trim().match(/^取り消し|取消し|取消|削除|とりけし[\!]*/)) {
+            if(messageText.trim().match(/^取り消し|^取消し|^取消|^削除|^とりけし[\!]*/)) {
+              // 取り消し
               replyIgnoreResultInstruction(sourcename, replyToken, replyTo);
               break;
             }


### PR DESCRIPTION
close #97 

- [x] 「取り消し」「削除」「取消し」「取消」いずれも先頭にあれば反応する（候補リスト表示）こと。
- [x] 上記がメッセージの途中に含まれても反応しないこと。