### PR TITLE
#87 「集計」にリレーと会場外の記録を統合

### DIFF
--- a/tests.gs
+++ b/tests.gs
@@ -1288,6 +1288,16 @@ function testGetPreviousSummary() {
   console.log(getPreviousSummary('group-Id-in-the-sheet-for-development'));
 }
 
+// getPreviousOuterSummary() のテスト
+function testGetPreviousOuterSummary() {
+  console.log(getPreviousOuterSummary('group-Id-in-the-sheet-for-development'));
+}
+
+// getOuterSummary() のテスト
+function testGetOuterSummary() {
+  console.log(getOuterSummary('group-Id-in-the-sheet-for-development'));
+}
+
 // addResult() のテスト
 function testAddResult() {
   console.log(addResult("tag", "浦和うなこ", "group-Id-in-the-sheet-for-development", "10.02", "1:23:45", "", "",  "user-Id-in-the-sheet-for-development"));
@@ -1338,6 +1348,12 @@ function testSubmitParticipants() {
   console.log(result);
 }
 
+// 記録フォームに表示する参加者候補リストを作成
 function testGetParticipantsFromSheet() {
   console.log(getParticipantsFromSheet());
+}
+
+// リレーの集計
+function testgetRelaySummary() {
+  console.log(getRelaySummary('group-Id-in-the-sheet-for-development'));
 }

--- a/tests.gs
+++ b/tests.gs
@@ -1288,14 +1288,36 @@ function testGetPreviousSummary() {
   console.log(getPreviousSummary('group-Id-in-the-sheet-for-development'));
 }
 
-// getPreviousOuterSummary() のテスト
-function testGetPreviousOuterSummary() {
-  console.log(getPreviousOuterSummary('group-Id-in-the-sheet-for-development'));
+// getCurrentPeriod() のテスト
+function testGetCurrentPeriod() {
+  var today = new Date();
+  console.log(today);
+  console.log(getCurrentPeriod('group-Id-in-the-sheet-for-development', today));
+  var yesterday = new Date();
+  yesterday.setDate(today.getDate()-1);
+  console.log(yesterday);
+  console.log(getCurrentPeriod('group-Id-in-the-sheet-for-development', yesterday));
+}
+
+// getNextPeriod() のテスト
+function testGetNextPeriod() {
+  var today = new Date();
+  console.log(today);
+  console.log(getNextPeriod('group-Id-in-the-sheet-for-development', today));
+  var yesterday = new Date();
+  yesterday.setDate(today.getDate()-1);
+  console.log(yesterday);
+  console.log(getNextPeriod('group-Id-in-the-sheet-for-development', yesterday));
 }
 
 // getOuterSummary() のテスト
 function testGetOuterSummary() {
-  console.log(getOuterSummary('group-Id-in-the-sheet-for-development'));
+  var today = new Date();
+  console.log(getOuterSummary('group-Id-in-the-sheet-for-development', today));
+  var yesterday = new Date();
+  yesterday.setDate(today.getDate()-1);
+  console.log(yesterday);
+  console.log(getOuterSummary('group-Id-in-the-sheet-for-development', yesterday));
 }
 
 // addResult() のテスト
@@ -1355,5 +1377,10 @@ function testGetParticipantsFromSheet() {
 
 // リレーの集計
 function testgetRelaySummary() {
-  console.log(getRelaySummary('group-Id-in-the-sheet-for-development'));
+  var today = new Date();
+  console.log(getRelaySummary('group-Id-in-the-sheet-for-development', today));
+  var yesterday = new Date();
+  yesterday.setDate(today.getDate()-1);
+  console.log(yesterday);
+  console.log(getRelaySummary('group-Id-in-the-sheet-for-development', yesterday));
 }


### PR DESCRIPTION
close #87 

# 変更の概要
「集計」で表示される内容を以下の通り見直した。

- リレー参加者の周回数と会場外参加者の距離を表示するようにした。
- 明日に向けての会場外のラン記録もあれば続いて表示されるようにした。
- 8:30を境に昨日の会場外集計から本日（翌日分）の集計に変わっていたが、いつ集計してもその日の集計となるようにした。

リリース後の確認事項

- [ ] 「集計」で今日の記録が前日から8:10までの分が表示されること
- [ ] 記録表の登録があれば、それも表示されること。
- [ ] その場合、全体の距離も表示されること。
- [ ] 記録表の登録がない状態では、会場外の計の下に、残りkmが表示されること
- [ ] 明日に向けてのラン記録があれば表示されること
- [ ] 「昨日の集計」はおとといから昨日の8:10までの会場外のみ表示されること（今後対応予定）
- [ ] 個人チャットでの「集計」は従前通り動作すること
