### PR TITLE
参加中イベントの集計をラン記録に合わせて表示

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -224,6 +224,10 @@ function doPost(e) {
               messageText += 'タイム' + String.fromCharCode(9) + (duration != null ? duration : '??');
               if(duration != null && distance != null && name != 'unknown') {
                 // 正常。修正の確認は不要。
+                var eventInfo = getEventSummaryPersonal(groupId, userId);
+                if(eventInfo != null) {
+                  messageText += `\n\n${eventInfo.summary}`;
+                }
                 replyLine(sourcename, replyToken, messageText);
               } else if(name == 'unknown') {
                 // 名前が未設定

--- a/tests.gs
+++ b/tests.gs
@@ -1391,3 +1391,19 @@ function testCancelRelayRecordWithinPeriod() {
   cancelRelayRecordWithinPeriod('group-Id-in-the-sheet-for-development', targetDate);
 }
 
+// 開催中のイベントを取得する
+function testGetEventInfo() {
+  var targetDate = new Date("2024/08/04 12:34:56");
+  console.log(getEventInfo('group-Id-in-the-sheet-for-development', targetDate));
+}
+
+// 特定イベントの参加状況を取得する
+function testGetEventAttendInfo() {
+  console.log(getEventAttendInfo('event-Id-in-the-sheet-for-development', 'user-Id-in-the-sheet-for-development'));
+}
+
+// 開催中のイベント参加状況を取得する
+function testGetEventSummaryPersonal() {
+  var targetDate = new Date("2024/08/04 12:34:56");
+  console.log(getEventSummaryPersonal('group-Id-in-the-sheet-for-development', 'user-Id-in-the-sheet-for-development', targetDate));
+}


### PR DESCRIPTION
close #116

イベント情報と参加者を登録しておくと、期間中ラン記録にイベントの集計も表示するようにした。

- [x] Event Listシートを作成した
- [x] Event Attendiesシートを作成した。
- [x] イベント期間中（Event List）で参加が登録（Event Attendies）されている場合は、ラン画像を投稿した際の記録に集計も表示される。
- [x] イベント期間中であっても参加していない場合は通常の表示がされる。
- [x] イベント期間前であれば、参加していても通常の表示がされる。
- [x] イベント期間後であれば、参加していても通常の表示がされる。
