### PR TITLE
参加中イベントの判定が誤る場合があった不具合の修正

### DIFF
--- a/tests.gs
+++ b/tests.gs
@@ -1394,7 +1394,7 @@ function testCancelRelayRecordWithinPeriod() {
 // 開催中のイベントを取得する
 function testGetEventInfo() {
   var targetDate = new Date("2024/08/04 12:34:56");
-  console.log(getEventInfo('group-Id-in-the-sheet-for-development', targetDate));
+  console.log(getEventInfo('group-Id-in-the-sheet-for-development'));
 }
 
 // 特定イベントの参加状況を取得する

--- a/tests.gs
+++ b/tests.gs
@@ -1394,7 +1394,7 @@ function testCancelRelayRecordWithinPeriod() {
 // 開催中のイベントを取得する
 function testGetEventInfo() {
   var targetDate = new Date("2024/08/04 12:34:56");
-  console.log(getEventInfo('group-Id-in-the-sheet-for-development'));
+  console.log(getEventInfo('group-Id-in-the-sheet-for-development', targetDate));
 }
 
 // 特定イベントの参加状況を取得する

--- a/util.gs
+++ b/util.gs
@@ -1070,8 +1070,8 @@ function getEventSummaryPersonal(groupId, userId, targetDate) {
   // イベント期間中の走行記録を集計
   var ss = SpreadsheetApp.getActive()
   var sheet = ss.getSheetByName('Monthly Report');
-  var date_from = Utilities.formatDate(eventInfo.eventStart, "JST", "yyyy-MM-dd hh:mm:ss");
-  var date_to = Utilities.formatDate(eventInfo.eventEnd, "JST", "yyyy-MM-dd hh:mm:ss");
+  var date_from = Utilities.formatDate(eventInfo.eventStart, "JST", "yyyy-MM-dd HH:mm:ss");
+  var date_to = Utilities.formatDate(eventInfo.eventEnd, "JST", "yyyy-MM-dd HH:mm:ss");
   var result = `参加中のイベント: ${eventInfo.eventName}\n`;
 
   // queryの条件（抽出対象期間）を更新
@@ -1130,7 +1130,7 @@ function getEventInfo(groupId, targetDate) {
   }
   // スプレッドシートとシートを取得
   var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Event List');
-  var date_param = Utilities.formatDate(dt, "JST", "yyyy-MM-dd hh:mm:ss");
+  var date_param = Utilities.formatDate(dt, "JST", "yyyy-MM-dd HH:mm:ss");
   // queryの条件（抽出対象期間）を更新
   sheet.getRange(1, 7).setValue(`=QUERY(A:E, "select A, B, C, D, E where E > datetime '${date_param}' and D < datetime '${date_param}'",TRUE)`);
   var data = sheet.getRange('G2:K').getValues();


### PR DESCRIPTION
close #123

# 概要
イベント期間の始まりの午後になると、しばらく期間中と判定されずラン記録に参加中のイベント情報が表示されなかった。
8/6 8:00スタートとしていたが、正午以降に投稿されたラン画像に参加中のイベント表示がつかなかった。
22:00に投稿されたラン画像には表示された。これは午後8時を過ぎたため、開始時刻以降と判定されるようになった。

- [x] 午後の時間でも正しく判定が行われることを、セットされた計算式で確認する。

