### PR TITLE
イベント集計表示

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -157,6 +157,10 @@ function doPost(e) {
               }
               break;
             }
+            if(messageText.trim().match(/^イベント[\s]*$/)) {
+              replyLine(sourcename, replyToken, getEvent(replyTo));
+              break;
+            }
             if(messageText.trim().match(/^修正[\s]*$/)) {
               replyUpdateResultInstruction(sourcename, replyToken, replyTo);
               break;

--- a/tests.gs
+++ b/tests.gs
@@ -1392,9 +1392,14 @@ function testCancelRelayRecordWithinPeriod() {
 }
 
 // 開催中のイベントを取得する
-function testGetEventInfo() {
+function testGetLatestEventInfo() {
   var targetDate = new Date("2024/08/04 12:34:56");
-  console.log(getEventInfo('group-Id-in-the-sheet-for-development', targetDate));
+  console.log(getLatestEventInfo('group-Id-in-the-sheet-for-development', targetDate));
+}
+
+// 特定イベントの情報を取得する
+function testGetEventInfo() {
+  console.log(getEventInfo('group-Id-in-the-sheet-for-development', 'event-Id-in-the-sheet-for-development'));
 }
 
 // 特定イベントの参加状況を取得する
@@ -1406,4 +1411,24 @@ function testGetEventAttendInfo() {
 function testGetEventSummaryPersonal() {
   var targetDate = new Date("2024/08/04 12:34:56");
   console.log(getEventSummaryPersonal('group-Id-in-the-sheet-for-development', 'user-Id-in-the-sheet-for-development', targetDate));
+}
+
+// 特定イベントの参加者を取得する
+function testGetEventAttendies() {
+  console.log(getEventAttendies('event-Id-in-the-sheet-for-development'));
+}
+
+// 特定イベントの集計を取得する
+function testGetEventSummary() {
+  console.log(getEventSummary('group-Id-in-the-sheet-for-development', 'event-Id-in-the-sheet-for-development'));
+}
+
+// 特定イベントの集計を取得する（参加者リスト付き）
+function testGetEventDetail() {
+  console.log(getEventSummary('group-Id-in-the-sheet-for-development', 'event-Id-in-the-sheet-for-development', true));
+}
+
+// 「イベント」
+function testGetEvent() {
+  console.log(getEvent('group-Id-in-the-sheet-for-development'));
 }


### PR DESCRIPTION
close #122 

イベント表示を実装。

既存のロジックをリファクタリングしたところ
getEventInfo() -> getLatestEventInfo() に変更

- [x] ラン画像を投稿した時に参加中のイベント情報が表示される
- [x] 参加していないイベントが開催中の場合はラン画像の投稿では表示されない

追加した機能

- [x] 「集計」で、開催中のイベントがあればイベント情報を表示する
- [x] 開催中だがまだ記録がない場合もイベント情報は表示される
- [x] 開催中かつ参加者がまだいない場合もイベント情報は表示される
- [x] 「集計」で、リレーや会場外のラン記録がない場合はイベントの詳細版が表示される
- [x] 「イベント」で詳細版が表示される
- [x] 詳細版には、走った人の集計が目標距離とともに表示される