### PR TITLE
「修正」や「取消」でリストが表示されず実行できないことがある不具合を修正

### DIFF
--- a/tests.gs
+++ b/tests.gs
@@ -1299,11 +1299,16 @@ function testGetPreviousSummary() {
 // getCurrentPeriod() のテスト
 function testGetCurrentPeriod() {
   var today = new Date();
-  console.log(today);
+  console.log(`today, just now: ${today}`);
   console.log(getCurrentPeriod('group-Id-in-the-sheet-for-development', today));
+
+  today.setHours(6);
+  console.log(`today, early time: ${today}`);
+  console.log(getCurrentPeriod('group-Id-in-the-sheet-for-development', today));
+
   var yesterday = new Date();
   yesterday.setDate(today.getDate()-1);
-  console.log(yesterday);
+  console.log(`yesterday: ${yesterday}`);
   console.log(getCurrentPeriod('group-Id-in-the-sheet-for-development', yesterday));
 }
 

--- a/tests.gs
+++ b/tests.gs
@@ -1315,11 +1315,16 @@ function testGetCurrentPeriod() {
 // getNextPeriod() のテスト
 function testGetNextPeriod() {
   var today = new Date();
-  console.log(today);
+  console.log(`today, just now: ${today}`);
   console.log(getNextPeriod('group-Id-in-the-sheet-for-development', today));
+
+  today.setHours(6);
+  console.log(`today, early time: ${today}`);
+  console.log(getNextPeriod('group-Id-in-the-sheet-for-development', today));
+
   var yesterday = new Date();
   yesterday.setDate(today.getDate()-1);
-  console.log(yesterday);
+  console.log(`yesterday: ${yesterday}`);
   console.log(getNextPeriod('group-Id-in-the-sheet-for-development', yesterday));
 }
 

--- a/util.gs
+++ b/util.gs
@@ -869,6 +869,9 @@ function getNextPeriod(groupId, targetDate) {
   if(targetDate != null) {
     dt = new Date(targetDate.getTime()); // targetDateのコピーを作成
   }
+  if(dt.getHours() * 100 + dt.getMinutes() > 830) {
+    dt.setDate(dt.getDate() +1);
+  }
   dt.setHours(8);
   dt.setMinutes(10);
   dt.setSeconds(0);

--- a/util.gs
+++ b/util.gs
@@ -852,7 +852,9 @@ function getCurrentPeriod(groupId, targetDate) {
   if(targetDate != null) {
     dt = new Date(targetDate.getTime()); // targetDateのコピーを作成
   }
-  dt.setDate(dt.getDate() -1);
+  if(dt.getHours() * 100 + dt.getMinutes() < 830) {
+    dt.setDate(dt.getDate() -1);
+  }
   dt.setHours(8);
   dt.setMinutes(10);
   dt.setSeconds(0);

--- a/util.gs
+++ b/util.gs
@@ -926,9 +926,12 @@ function getLastMonthStart(targetDate) {
 
 // グループの集計
 function getSummary(groupId) {
+  // TODO: 固定で朝6時を基準にしているが、グループにより会場外の集計対象時間が異なるため考慮が必要
   var today = new Date();
+  today.setHours(6);
   var tommorow = new Date();
   tommorow.setDate(today.getDate()+1);
+  tommorow.setHours(6);
   var relayResult = getRelaySummary(groupId, today);
   var outerResult = getOuterSummary(groupId, today);
   var tommorowOuterResult = getOuterSummary(groupId, tommorow);


### PR DESCRIPTION
close #124 

# みどころ
集計対象の期間を調整していた箇所に問題があった。
当日の8:30までは前日の8:10からを集計対象とするところを、一律前日の8:10としてしまっていた。
そのため、8:30以降に「修正」や「取消」を行なった場合、昨日のランを含んだリストが表示されていた。
そして累積が13件を超えるとLINEのポストバックアクションの上限に引っかかり、APIエラーとなっていた。

# 確認方法

- [x] 8:30を過ぎていたら、当日8:10からを対象に修正候補のリストが作られる
- [x] 同様に、個人の「集計」で今日走った分が加算されている
- [x] グループでの「集計」に、おとといの分は含まれず今日の分だけが会場外に表示されている

