### PR TITLE
TATTAのタイム調整

### DIFF
--- a/tests.gs
+++ b/tests.gs
@@ -1178,9 +1178,47 @@ var sample44 = `ランニング
 07'07.4km
 SUUN`;
 
+var sample45 = `10:07
+17:52
+Walking
+2024/8/29 (*) 10:41
+步数
+4,868
+タイム
+距離
+3.52km
+消費カロリー
+0:44:13 204kcal
+0:00
+7:22
+14:44
+22:06
+29:28
+44:13`;
+
+var sample46 = `Running
+2024/8/29 (*) 9:40
+タイム
+距離
+ঘ
+0:25:05 5.00km
+最速ペース
+4:42/km
+平均ペース
+5:01/km
+3:59
+6:00
+0:00
+4:10
+8:20
+12:30
+16:40 25:05`;
+
 function newTest() {
   var result = '';
   result += detectTest('sample44', sample44, '1:11:10', '10.00'); // SUUNTO
+  result += detectTest('sample45', sample45, '0:44:13', '3.52'); // TATTA
+  result += detectTest('sample46', sample46, '0:25:05', '5.00'); // TATTA
  
   console.log(`results: ${result}`);
 }
@@ -1231,6 +1269,8 @@ function myTest() {
   result += detectTest('sample42', sample42, '0:10:43', '1.02'); // TATTA English
   result += detectTest('sample43', sample43, '0:56:30.2', '8.01'); // SUUNTO
   result += detectTest('sample44', sample44, '1:11:10', '10.00'); // SUUNTO
+  result += detectTest('sample45', sample45, '0:44:13', '3.52'); // TATTA
+  result += detectTest('sample46', sample46, '0:25:05', '5.00'); // TATTA
 
   console.log(`results: ${result}`);
 }

--- a/util.gs
+++ b/util.gs
@@ -36,27 +36,14 @@ function detectTime(result) {
     console.log('match dt3');
     return a[1] + ':' + a[2] + ':' + a[3];
   }
-  // 0:49'01" LAP
-  // 01:00′ 15"-
-  a = [...result.matchAll(/([0-9]+):([0-5][0-9])[\'′ ]*([0-5])[ ]*([0-9])[\"\″]*/g)];
-  if ( a.length > 0) {
-    console.log(`match dt6 with ${a.length} patterns.`);
-    for(i=0; i<a.length;i++) {
-      duration = a[i][1] + ':' + a[i][2] + ':' + a[i][3] + a[i][4];
-      if(duration != '0:00:00') {
-        // TODO: 複数あったら返して選択してもらう。
-        return duration;
-      }
-    }
-  }
   // 00:55:29.3
-  a = result.match(/([0-9]+):([0-5][0-9])[:\'′]([0-5][0-9])\.([0-9]{1,3})/);
+  a = result.match(/([0-9]+):([0-5][0-9])[:\'′]([0-5][0-9])\.([0-9]{1,3})(?!km)/);
   if ( a != null) {
     console.log('match dt1');
     return a[1] + ':' + a[2] + ':' + a[3] + '.' + a[4];
   }
   // 5:59.6
-  a = result.match(/([0-5]*[0-9])[:\'′]([0-5][0-9])\.([0-9]{1,3})/);
+  a = result.match(/([0-5]*[0-9])[:\'′]([0-5][0-9])\.([0-9]{1,3})(?!km)/);
   if ( a != null) {
     console.log('match dt1\'');
     return '0:' + a[1] + ':' + a[2] + '.' + a[3];
@@ -73,6 +60,19 @@ function detectTime(result) {
   if ( a != null) {
     console.log('match dt4');
     return '0:' + a[1] + ':' + a[2];
+  }
+  // 0:49'01" LAP
+  // 01:00′ 15"-
+  a = [...result.matchAll(/([0-9]+):([0-5][0-9])[\'′ ]*([0-5])[ ]*([0-9])[\"\″]*/g)];
+  if ( a.length > 0) {
+    console.log(`match dt6 with ${a.length} patterns.`);
+    for(i=0; i<a.length;i++) {
+      duration = a[i][1] + ':' + a[i][2] + ':' + a[i][3] + a[i][4];
+      if(duration != '0:00:00') {
+        // TODO: 複数あったら返して選択してもらう。
+        return duration;
+      }
+    }
   }
   // 01:00
   a = [...result.matchAll(/\n([0-5]{0,1}[0-9]):([0-5][0-9])\n/g)];


### PR DESCRIPTION
close #135

タイムの検出ではkmが付かないはずなので、それを除外するように調整。
誤検知のもとになっていた特殊な判定（dt6）を後ろに回した。

- [x] 今回のラン画像が正しく認識されること
- [x] MyTestが全てOKになっていること