### PR TITLE
14件以上記録がある場合のクイックリプライを直近の13件にして使えるようにする

### DIFF
--- a/util.gs
+++ b/util.gs
@@ -1593,11 +1593,16 @@ function replyUpdateResultInstruction(sourcename, replyToken, groupId){
   var items = [];
   for(i = 1; i < sheet.getLastRow(); i++) {
     if(records[i][0] == '') {
+      // まだ記録が少ない時の空行はスキップ（右側の集計計算式のため、getLastRow()は最低3になり、1件の時は空行も読むため）
       continue;
     }
     var distance = records[i][1] != '' ? records[i][1] : '??'
     var duration = records[i][2] != '' ? records[i][2] : '??'
     result += `${i}. ${records[i][0]}\t${distance}\t${duration}\n`;
+    if(sheet.getLastRow() - i > 13) {
+      // 14件以上あるとクリックリプライで対応できないため、最新13件を候補にする
+      continue;
+    }
     items.push(
       {
         'type': 'action', 
@@ -1654,9 +1659,16 @@ function replyIgnoreResultInstruction(sourcename, replyToken, groupId){
   var items = [];
   for(i = 1; i < sheet.getLastRow(); i++) {
     if(records[i][0] == '') {
+      // まだ記録が少ない時の空行はスキップ（右側の集計計算式のため、getLastRow()は最低3になり、1件の時は空行も読むため）
       continue;
     }
-    result += `${i}. ${records[i][0]}\t${records[i][1]}\t${records[i][2]}\n`;
+    var distance = records[i][1] != '' ? records[i][1] : '??'
+    var duration = records[i][2] != '' ? records[i][2] : '??'
+    result += `${i}. ${records[i][0]}\t${distance}\t${duration}\n`;
+    if(sheet.getLastRow() - i > 13) {
+      // 14件以上あるとクリックリプライで対応できないため、最新13件を候補にする
+      continue;
+    }
     items.push(
       {
         'type': 'action', 


### PR DESCRIPTION
close #144 

「修正」と「削除」で対象を選択するために表示しているクイックリプライが、LINEの仕様上13件までのため記録が14件以上ある場合はエラーになって無反応だった。

14件以上ある場合は、リストはすべて表示し選択は直近の13件の記録から選択するようにした。

- [x] 記録がない場合は「まだ記録がありません」と表示される。
- [x] 1件だけ記録がある場合は1件だけ表示される。
- [x] 2件以上記録がある場合も記録がすべて表示される。
- [x] 14件以上ある場合、記録はすべて表示され、クイックリプライは直近の13件が表示される。
- [x] 14件以上ある場合も、選択した記録が修正できる。（「修正」の場合）
- [x] 14件以上ある場合も、選択した記録が削除される。（「削除」の場合）