### PR TITLE
unknownでUser Listに重複登録しないよう修正

### DIFF
--- a/tests.gs
+++ b/tests.gs
@@ -1581,3 +1581,9 @@ function testGetQuotedUserId() {
   console.log(getQuotedUserId('hoge'));
   console.log(getQuotedUserId('526271456615858273'));
 }
+
+// isExistUser(userId)
+function testIsExistUser() {
+  console.log(`isExistUser("hogehoge"): ${isExistUser("hogehoge")}`);
+  console.log(`isExistUser("user-Id-in-the-sheet-for-development"): ${isExistUser("user-Id-in-the-sheet-for-development")}`);
+}

--- a/util.gs
+++ b/util.gs
@@ -606,7 +606,7 @@ function recordResult(event, analyzed, textAnnotations, distance, duration) {
         break;
       case "name":
         val = getListedUserName(userId);
-        if(val == 'unknown') {
+        if(val == 'unknown' && !isExistUser(userId)) {
           // リストになければ追加しておく
           recordUser(userId);
         }
@@ -844,6 +844,23 @@ function ignoreResult(tag) {
     }
   }
   return '記録がありません';
+
+}
+
+// ユーザ登録チェック
+function isExistUser(userId) {
+
+  var ss = SpreadsheetApp.getActive()
+  var sheet = ss.getSheetByName('User List');
+
+  const lastRow = sheet.getLastRow();
+
+  for (var i = 2; i <= lastRow; i++) {
+    if (sheet.getRange(i, 1).getValue() == userId) {
+      return true;
+    }
+  }
+  return false;
 
 }
 


### PR DESCRIPTION
close #160 

新しく登録されたユーザの名前設定がされないままラン画像が送信されると User Listに重複してレコードが作成されていた問題を修正。

- [x] 最初にラン画像を送信した時にはUser Listにunknownで追加されること
- [x] 名前設定のクイックリプライが使用されずそのままの状態で次のラン画像が送信されてもUser Listにレコードが追加されないこと
- [x] 名前設定のアクションから変更が送信されるとUser Listに名前が保存され、記録上も更新されていること。

二番めのケースになった場合、一番めの記録はunknownのままだが、これは別issueで検討する。
グループチャットの場合は「修正」で選択して修正できる。