### PR TITLE
記録表フォームのパターン追加（除夜の鐘2024）

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -349,13 +349,28 @@ function submitParticipants(groupId, participants, selectedLap) {
     // ここでデータをスプレッドシートに保存するなどの処理を行う
     console.log(`${groupId} - 名前: ${participant.name}, 周回数: ${participant.laps}`);
     result += `\n${participant.name} (${participant.laps})`
-    var distance = participant.laps * 923.2;
-    if (index === 0) {
-      // 先頭の参加者は１周目とみなし、ショートコースの差分を差し引く。（別所沼ルール）
-      distance -= selectedLap; // #134
+    var distance = 0;
+    var venue = '別所沼公園';
+    if(selectedLap == 384) {
+      // 別所沼：除夜の鐘2024
+      distance = participant.laps * 384;
+      venue = '別所沼：除夜の鐘2024';
+      if (participant.extras > 0) {
+        // 106周目〜108周目は651m
+        distance += 267 * participant.extras; // 1周につき267m加算
+        venue += `(${participant.extras})`; // 誰が長目を何周走ったか記録
+      }
+    }
+    else {
+      // 別所沼：通常リレー
+      distance = participant.laps * 923.2;
+      if (index === 0) {
+        // 先頭の参加者は１周目とみなし、ショートコースの差分を差し引く。（別所沼ルール）
+        distance -= selectedLap; // #134
+      }
     }
     // TODO: 会場も記録されるようにする。会場ごとに周回の距離も異なる。
-    addResult("tag", participant.name, groupId, distance/1000, "", participant.laps, "別所沼公園", "dummy");
+    addResult("tag", participant.name, groupId, distance/1000, "", participant.laps, venue, "dummy");
   });
 
   console.log(`${groupId}\nリレー参加記録フォームからの登録を記録しました。\n${result}`);

--- a/relayentryform.html
+++ b/relayentryform.html
@@ -33,6 +33,10 @@
             width: 50px;
             margin-right: 10px;
         }
+        .form-row .extras-input {
+            width: 25px;
+            margin-right: 10px;
+        }
         .form-row button {
             width: auto;
             white-space: nowrap;
@@ -122,9 +126,12 @@
 
     <div id="form-container">
         <div class="lap-selection">
-            1周目: 
-            <label for="lap1"><input type="radio" id="lap1" name="1stlap" value="539.2" checked> 384m</label>
-            <label for="lap2"><input type="radio" id="lap2" name="1stlap" value="272.2"> 651m</label>
+            コース（会場）: 
+            <select id="lap-selection" name="1stlap">
+                <option value="539.2" data-guide="先頭ランナー6周で5km" selected>別所沼：会員リレー</option>
+                <option value="272.2" data-guide="先頭ランナーはショートコース">別所沼：チームリレー（フルマラソン）</option>
+                <option value="384" data-guide="（　）内は106周〜108周の内数">別所沼：除夜の鐘リレーマラソン２０２４</option>
+            </select>
         </div>
         <? for (var i = 0; i < existingRecords.length; i++) { ?>
         <div class="form-row">
@@ -135,6 +142,7 @@
                 <? } ?>
             </datalist>
             <input type="number" class="laps-input" value="<?= existingRecords[i].laps ?>" placeholder="周回数" maxlength="2">
+            （<input type="number" class="extras-input" value="<?= existingRecords[i].extras ?>" maxlength="2">）
             <? if (i === existingRecords.length - 1) { ?>
             <button type="button" onclick="addRow(this)">追加</button>
             <? } else { ?>
@@ -143,6 +151,7 @@
         </div>
         <? } ?>
     </div>
+    <div id="guidance-message" style="display:none; color: green; margin-bottom: 10px;"></div>
     <button type="button" onclick="showModal()">確認</button>
 
     <div id="modal">
@@ -155,6 +164,7 @@
     <div class="instructions">
       <ul>
         <li>１周目のランナーを先頭にしてください。</li>
+        <li>（　）内は106周〜108周の内数を入力します。（除夜の鐘リレーマラソン用）</li>
         <li>送信完了後、「集計」で確認をお願いします。</li>
         <li>ランナーと周回数がすでに表示されている場合は記録済みです。修正が必要な場合は編集して送信ください。</li>
       </ul>
@@ -176,6 +186,13 @@
             lapsInput.classList.add('laps-input');
             lapsInput.placeholder = '周回数';
 
+            const extrasWrapperOpen = document.createTextNode(' （ ');
+            const extrasInput = document.createElement('input');
+            extrasInput.type = 'number';
+            extrasInput.classList.add('extras-input');
+            extrasInput.placeholder = '';
+            const extrasWrapperClose = document.createTextNode(' ） ');
+            
             const addButton = document.createElement('button');
             addButton.type = 'button';
             addButton.textContent = '追加';
@@ -190,6 +207,9 @@
 
             newRow.appendChild(participantInput);
             newRow.appendChild(lapsInput);
+            newRow.appendChild(extrasWrapperOpen);
+            newRow.appendChild(extrasInput);
+            newRow.appendChild(extrasWrapperClose);
             newRow.appendChild(addButton);
             formContainer.appendChild(newRow);
         }
@@ -201,9 +221,13 @@
             formRows.forEach(row => {
                 const name = row.querySelector('.participant-input').value;
                 const laps = row.querySelector('.laps-input').value;
+                const extras = row.querySelector('.extras-input').value;
                 if (name && laps) {
                     const listItem = document.createElement('li');
                     listItem.textContent = `${name}: ${laps}周`;
+                    if(extras) {
+                        listItem.textContent += ` (${extras})`;
+                    }
                     confirmationList.appendChild(listItem);
                 }
             });
@@ -221,15 +245,16 @@
             responseMessage.textContent = '送信しています';
             responseMessage.style.display = 'block';
             
-            const selectedLap = document.querySelector('input[name="1stlap"]:checked').value;
+            const selectedLap = document.getElementById('lap-selection').value;
 
             const participants = [];
             const formRows = document.querySelectorAll('.form-row');
             formRows.forEach(row => {
                 const name = row.querySelector('.participant-input').value;
                 const laps = row.querySelector('.laps-input').value;
+                const extras = row.querySelector('.extras-input').value;
                 if (name && laps) {
-                    participants.push({ name, laps });
+                    participants.push({ name, laps, extras });
                 }
             });
             google.script.run.withSuccessHandler(function(response) {

--- a/tests.gs
+++ b/tests.gs
@@ -1571,6 +1571,20 @@ function testSubmitParticipants() {
   console.log(result);
 }
 
+function testSubmitParticipants108() {
+  // テスト用のparticipantsリストを生成
+  var participants = [
+    {name: "山田 太郎", laps: 6, extras: ''},
+    {name: "浦和うなこ", laps: 52, extras: ''},
+    {name: "田中 花子", laps: 33, extras: 2},
+    {name: "鈴木 一郎", laps: 17, extras: 1}
+  ];
+
+  // submitParticipants関数を呼び出してテスト
+  var result = submitParticipants("group-Id-in-the-sheet-for-development", participants, "384");
+  console.log(result);
+}
+
 // 記録フォームに表示する参加者候補リストを作成
 function testGetParticipantsFromSheet() {
   console.log(getParticipantsFromSheet('group-Id-in-the-sheet-for-development'));


### PR DESCRIPTION
close #167 

記録表に第3のパターンとして2024年特別ルールの除夜の鐘リレーマラソンを追加。

これまで、会員リレー（先頭ランナーが6周すると5kmになるよう調整された1周目）とフルマラソン（1周目がショートコース）があったが、1周目の距離を選択するラジオボタンから、コース（会場）を選ぶドロップダウンリストに変更した。

- [x] これまでの２パターンがそれぞれ従前通り記録されること
- [x] 追加した除夜の鐘リレーは、1周384mで集計されること
- [x] （）に記入した場合、周回数分距離が加算されていること
