### PR TITLE
広島長崎リレーマラソンの速報画像を除外

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -231,6 +231,10 @@ function doPost(e) {
             if(records != null) {
               // 記録表の写メだった場合はメッセージを返して終了
               recordResult(event, result, JSON.stringify(obj), '', '');
+              // 記録表以外の除外画像の場合は何も返さず終了
+              if(records == '') {
+                break;
+              }
               // TODO: フォームが対応したら年月日もパラメータで渡す
               var formUrl = ScriptApp.getService().getUrl() + '?groupId=' + groupId;
               var note = '\n\n登録後、「集計」で記録を確認してください。'

--- a/tests.gs
+++ b/tests.gs
@@ -1557,6 +1557,64 @@ function testDetectSheet() {
   console.log(detectSheet(sheetSample3));
 }
 
+const sheetSample4 = `Hiroshima
+Nagasaki
+Relay
+RUN
+DREAMS
+Marathon
+2025
+申告距離
+8/6 8/7 8/8
+8/9
+実施距離
+浦和うなこ
+7.4
+7.4
+合計距離
+337.2
+75.9
+0.0
+0.0 0.0
+75.9
+目標距離 423.4
+実施距離一目標距離 -347.5
+1. 集計期間 8月6日/8:30 ~ 8月9日/11:00 [約72時間 ]
+2.8/6の別所沼ランの報告数値に相違あり 訂正数値で集計`;
+
+const sheetSample5 = `Hiroshima
+Nagasaki
+Relay
+Marathon
+RUN DREAMS
+2025
+申告距離
+8/6 8/7 8/8
+8/9 実施距離
+浦和うなこ
+7.4
+7.4
+合計距離
+337.2 90.4 0.0
+0.0 0.0
+90.4
+目標距離 423.4
+実施距離一目標距離 -333.0
+1. 集計期間 8月6日/8:30 ~ 8月9日/11:00 [約72時間]
+2.8/6の別所沼ランの報告数値に相違あり 訂正数値で集計`;
+
+function testDetectSheet() {
+  console.log(detectSheet(sample1));
+  console.log(detectSheet(sheetSample1));
+  // 付加情報が読み取れなかった場合
+  console.log(detectSheet(sheetSample2));
+  // タイトルが変更になった
+  console.log(detectSheet(sheetSample3));
+  // 広島長崎リレーマラソン
+  console.log(detectSheet(sheetSample4));
+  console.log(detectSheet(sheetSample5));
+}
+
 function testSubmitParticipants() {
   // テスト用のparticipantsリストを生成
   var participants = [

--- a/util.gs
+++ b/util.gs
@@ -5,8 +5,13 @@ function detectSheet(result) {
   // 最低限の判定
   let a = result.match(/Run Dreams 第/);
   let b = result.match(/^■.*\[(.*)\]/);
+  let c = result.match(/Hiroshima\nNagasaki\nRelay\n/); // 広島長崎リレーマラソン
   if ( a == null && b == null) {
-    return null;
+    if( c == null ) {
+      return null;
+    }
+    console.log('detect summary image.');
+    return ``;
   }
   // 日数と年月日も読み取りを試みる
   a = result.match(/Run Dreams 第(.*)日目([0-9]+)年([1]*[0-9])月([1-3]*[0-9])日/);


### PR DESCRIPTION
close #172 

イベント期間中に経過を速報する画像が誤認識されるので、除外文字列を含む画像はスキップするようにした。

- [x] 通常のラン画像が処理される
- [x] 広島長崎リレーマラソンの速報画像は処理されない
- [x] 別所沼の記録表は処理される